### PR TITLE
Add Surnet/graphql-amqp-subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ It can be easily replaced with some other implementations of [PubSubEngine inter
 - Use Google PubSub with https://github.com/axelspringer/graphql-google-pubsub
 - Use MQTT enabled broker with https://github.com/davidyaha/graphql-mqtt-subscriptions
 - Use RabbitMQ with https://github.com/cdmbase/graphql-rabbitmq-subscriptions
+- Use AMQP (RabbitMQ) with https://github.com/Surnet/graphql-amqp-subscriptions
 - Use Kafka with https://github.com/ancashoria/graphql-kafka-subscriptions
 - Use Postgres with https://github.com/GraphQLCollege/graphql-postgres-subscriptions
 - Use NATS with https://github.com/moonwalker/graphql-nats-subscriptions


### PR DESCRIPTION
Hi there,

I did develop another flavor of AMQP (RabbitMQ) subscriptions.
The main difference is the usage of [Topic Exchanges](https://www.cloudamqp.com/blog/2015-09-03-part4-rabbitmq-for-beginners-exchanges-routing-keys-bindings.html).

If you need further information please contact me.

Cheers,
Daniel

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [X] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->